### PR TITLE
chore: add allowJs to tsconfig

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -5,6 +5,7 @@
     "lib": ["ES2020", "DOM", "DOM.Iterable"],
     "module": "ESNext",
     "skipLibCheck": true,
+    "allowJs": true,
 
     /* Bundler mode */
     "moduleResolution": "bundler",


### PR DESCRIPTION
Some of our candidates don't want to use TS so they change files to JS. This causes some issues so this PR updates our `tsconfig.json` to allow JS files.